### PR TITLE
fix docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,6 @@ x-default-node: &default-node
     dockerfile: Dockerfile
   depends_on:
     - nats
-  volumes:
-    # Mount the .env file if it exists, otherwise the default will be used
-    - ./.env:/app/.env:ro
-    - ./storage:/app/storage
-    - ./node.db:/var/lib/gridlock/node/node.db
 
 services:
   nats:
@@ -29,15 +24,18 @@ services:
     container_name: guardian-node-1
     volumes:
       - ./storage/nodes/1:/var/lib/gridlock/node
+      - ./.env:/app/.env:ro
 
   node2:
     <<: *default-node
     container_name: guardian-node-2
     volumes:
       - ./storage/nodes/2:/var/lib/gridlock/node
+      - ./.env:/app/.env:ro
 
   node3:
     <<: *default-node
     container_name: guardian-node-3
     volumes:
       - ./storage/nodes/3:/var/lib/gridlock/node
+      - ./.env:/app/.env:ro


### PR DESCRIPTION
The docker compose file defined default volumes, but each guardian node was stomping on them. I also added some quick testing instructions to the readme.